### PR TITLE
Fixes details in home page

### DIFF
--- a/src/main/webapp/Home.xhtml
+++ b/src/main/webapp/Home.xhtml
@@ -7,65 +7,6 @@
   xmlns:p="http://primefaces.org/ui"
 >
   <ui:define name="titulo">SVSA</ui:define>
-  <ui:define name="header">
-     	<div class="containerHeader">
-	        <div class="containerImg">
-	          <a href="#{request.contextPath}">
-	          	<h:graphicImage alt="Logo da SVSA" library="imagens" name="svsa_t.png"></h:graphicImage>
-	          </a>
-	        </div>
-	        <nav class="navHomePage" id="nav">
-	          <i id="btnMobile" class="pi pi-bars"></i>
-	          <ul id="menu">
-	            <li>
-	              <a href="#{request.contextPath}/restricted/home/SvsaHome.xhtml" class="btnLogin">
-	                <i class="pi pi-user"></i>
-	                Login
-	              </a>
-	            </li>
-	            <li>
-	              <span class="divider"></span>
-	            </li>
-	            <li>
-	              <a href="#" aria-label="Ir para pagina de cadastro de municipio"> Cadastro de Município </a>
-	            </li>
-	            <li>
-	              <span class="divider"></span>
-	            </li>
-	            <li>
-	              <a href="#" aria-label="Ir para pagina de auto cadastro">Auto Cadastro</a>
-	            </li>
-	            <li>
-	              <span class="divider"></span>
-	            </li>
-	            <li>
-	              <div id="containerSocialNetwork">
-	                <ul>
-	                  <li>
-	                    <a href="https://www.facebook.com/GaianOficial/" class="iconFacebook" aria-label="Ir para a pagina do Facebook"
-	                      ><i class="pi pi-facebook"></i
-	                    ></a>
-	                  </li>
-	                  <li>
-	                    <a href="https://www.instagram.com/gaianoficial/" class="iconInstagram" aria-label="Ir para a pagina do Instagram"
-	                      ><i class="pi pi-instagram"></i
-	                    ></a>
-	                  </li>
-	                  <li>
-	                    <a href="https://www.youtube.com/channel/UCtDRtIaNumFjnO9DTvYDODw" class="iconYoutube" aria-label="Ir para o canal do YouTube">
-	                    	<i class="pi pi-youtube"></i>
-	                    </a>
-	                  </li>
-	                  <li>
-	                  	<i class="pi pi-moon switchThemeIcon"></i>
-	                  </li>
-	                </ul>
-	              </div>
-	            </li>
-	          </ul>
-	        </nav>
-      </div>
-    </ui:define>
   <ui:define name="corpo">
 	<section class="sectionIntroduction" id="sectionIntroduction">
       <div class="containerIntroduction">

--- a/src/main/webapp/WEB-INF/template/LayoutHome.xhtml
+++ b/src/main/webapp/WEB-INF/template/LayoutHome.xhtml
@@ -29,8 +29,7 @@
     <h:outputStylesheet library="css" name="global.css" />
     <h:outputStylesheet library="css" name="templates/headerHome.css" />
     <h:outputStylesheet library="css" name="home.css" />
-    <h:outputStylesheet library="css" name="templates/footer.css" />
-    <h:outputStylesheet library="css" name="sistema.css" /> 
+    <h:outputStylesheet library="css" name="templates/footer.css" /> 
   </h:head>
   <body>
     <header class="header" id="header">

--- a/src/main/webapp/WEB-INF/template/LayoutPadrao.xhtml
+++ b/src/main/webapp/WEB-INF/template/LayoutPadrao.xhtml
@@ -27,7 +27,6 @@
     />
     <title>SVSA - Gaian.com.br</title>
     <h:outputStylesheet library="css" name="global.css" />
-    <h:outputStylesheet library="css" name="templates/header.css" />
     <h:outputStylesheet library="css" name="sistema.css" /> 
     <h:outputStylesheet library="css" name="templates/footer.css" />
   </h:head>

--- a/src/main/webapp/pages/videosTreinamentos/videosTreinamentos.xhtml
+++ b/src/main/webapp/pages/videosTreinamentos/videosTreinamentos.xhtml
@@ -6,12 +6,10 @@
   xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
   xmlns:p="http://primefaces.org/ui"
 >
-  	
-  
   <ui:define name="titulo">Treinamento | SVSA</ui:define>
 
   <ui:define name="corpo">
-    <h:outputStylesheet library="css" name="videos.css"/>
+  <h:outputStylesheet library="css" name="videos.css"/>
 	<section class="sectionVideosContainer" id="sectionVideosIntro">
     <div class="containerVideosIntro">
       <div class="imageVideosIntro">

--- a/src/main/webapp/resources/css/global.css
+++ b/src/main/webapp/resources/css/global.css
@@ -200,16 +200,6 @@ body.dark{
 	--colorLowBarSectionTitle: #c7cdd0;
 }
 
-
-h1 {
-  font-size: 1.5rem;
-  font-weight: 500;
-}
-h3 {
-  font-size: 0.875rem;
-  font-weight: 300;
-}
-
 li {
   list-style: none;
 }

--- a/src/main/webapp/resources/css/videos.css
+++ b/src/main/webapp/resources/css/videos.css
@@ -13,6 +13,7 @@
 
 .videoText h1{
   font-size: 1.65rem;
+  font-weight: 500;
   color: var(--colorVideoTitle);
 }
 
@@ -95,6 +96,7 @@
  
 .contentVideosIntro h1 {
   font-size: 2.5rem;
+  font-weight: 500;
   padding: 1rem 0;
   color: var(--colorVideosIntroTitle);
 }
@@ -102,6 +104,7 @@
 .contentVideosIntro h3 {
   padding: 0.75rem 0;
   font-size: 1.20rem;
+  font-weight: 300;
   color: var(--colorVideosIntroSubtitle);
 }
 
@@ -173,5 +176,6 @@
 
 .endText h3{
   font-size: 1.60rem;
+  font-weight: 300;
   color: var(--colorLowBarSectionTitle);
 }


### PR DESCRIPTION
Esse PR adiciona pequenas alterações nas paginas: Home, Pagina de treinamentos e altera importação de css.

### Sobre o problema do tamanho de fontes nos formulários e menu

Foi analisado, utilizando uma ferramenta do navegador Firefox, do qual analisamos quais estilos estão sendo importados nas paginas de formulário, que seguem um **Layout diferente** do usado nas paginas Home, vídeos e pagina de erro. 

Foi concluído que nessas paginas são carregados:
-  Estilo do primefaces (theme.css.xhtml),
- Icons do primefaces(primeicons.css.xhtml), 
- sistema.css.xhtml
- components.css.xhtml

#### Exemplo na pagina de formulário de login
![DataLogin](https://user-images.githubusercontent.com/53938849/204067451-1f2ac146-0107-43f9-931a-fce7e1f1e57b.PNG)

#### Exemplo na pagina de formulário do Auto Cadastro
![DataAutoCad](https://user-images.githubusercontent.com/53938849/204067527-7b179038-666d-408d-9184-e8c2a4e2d100.PNG)

Logo, essas paginas utilizamos somente informações do primefaces para estilos, estilização de icones e conteudos presentes em sistema.css.xhtml

---

Nas paginas Home, Videos e Erro, os estilos carregados são esses:
![DataHomePage](https://user-images.githubusercontent.com/53938849/204067539-0bddbc1a-5045-44c3-bea0-7cac64049a76.PNG)

Testamos as paginas removendo a importação do primefaces (theme.css.xhtml) e o site não apresentou alterações, o que comprova que os estilos não estão se interferindo. Removendo a importação do primeicons, somente os icones são alterados, porém a estilização do site se mantém, mostrando que não há interferência.

Sendo assim, nesse commit mantivemos as estrutura de arquivos que já estamos desenvolvendo, apenas aplicação correções em estilos e removemos importações incorretas.
